### PR TITLE
added way to set groups which must not gift each others

### DIFF
--- a/Kris_Kingle.py
+++ b/Kris_Kingle.py
@@ -6,17 +6,50 @@ import smtplib
 
 participants = {
 'Vikas'   : 'Email ID of Vikas',  #Example: 'abc@gmail.com'
-'Dev'     : 'Email ID of Dev', #Example: 'bbc@gmail.com'
-'Mahek'   : 'Emai ID of Mahek', #Example: 'cbc@gmail.com'
-'Akash'  : 'Email ID of Akash', #Example: 'dbc@gmail.com'
+'Dev'     : 'Email ID of Dev',  #Example: 'bbc@gmail.com'
+'Mahek'   : 'Emai ID of Mahek',   #Example: 'cbc@gmail.com'
+'Akash'   : 'Email ID of Akash', #Example: 'dbc@gmail.com'
 'Vishal'  : 'Email ID of Vishal' #Example: 'lbc@gmail.com'
 }
 
-santa = list(np.random.choice(list(participants.keys()), len(list(participants.keys())), replace = False))
-receiver = []
-for i in range(-1, len(santa)-1):
-	receiver.append(santa[i])
-			
+
+#set groups of people which must not gift each other, 0 means no constrains, every other number is a group  
+
+constrains = {
+'Vikas'   : 0,
+'Dev'     : 0,
+'Mahek'   : 1,
+'Akash'   : 1,
+'Vishal'  : 0
+}
+
+
+def setRandom():
+	santa = list(np.random.choice(list(participants.keys()), len(list(participants.keys())), replace = False))
+	receiver = []
+	for i in range(-1, len(santa)-1):
+		receiver.append(santa[i])
+	return santa, receiver
+
+def checkConstrains():
+	for i in range(len(santa)):
+		print(i, santa[i], constrains[santa[i]], receiver[i], constrains[receiver[i]], sep = ' | ', end = '\n')
+		if santa[i]==receiver[i]:
+			return False
+		if constrains[santa[i]] and constrains[santa[i]] == constrains[receiver[i]]: #se il vincolo è diverso da 0 oppure se sono uguali
+			return False
+	return True
+
+
+
+
+
+santa, receiver = setRandom()
+while not checkConstrains():
+	santa, receiver = setRandom()
+print(santa, receiver)
+
+		
 #Keep less secured apps option turned on from your gmail account to avoid error while sending out the mail.
 
 smtpObj = smtplib.SMTP('smtp.gmail.com', 587)
@@ -28,15 +61,15 @@ smtpObj.login(email, password)
 
 for j in range(len(participants)):
 	smtpObj.sendmail(email, participants[santa[j]], \
-	'Subject: Kris Kingle 2022 \
+	'Subject: Secret Santa 2022 \
 	\nHo Ho Ho %s! \
 	\n\nChristmas is almost here, \
-	\n\nThis Kris Kingle you are gifting to....... %s!' % (santa[j], receiver[j]))
+	\n\nThis year you are gifting to....... %s!' % (santa[j], receiver[j]))
 
 smtpObj.quit()
 
-df = pd.DataFrame({'santa':santa, 'receiver':receiver})
-df.to_csv('Kris Kingle list.csv')
+#df = pd.DataFrame({'santa':santa, 'receiver':receiver})
+#df.to_csv('Kris Kingle list.csv')
 
 
 


### PR DESCRIPTION
With these changes you will be able to impose restrictions on who can give a gift to whom.
In the example you can see the conditions of the Secret Santa I'm planning with my cousins, where you cannot gift your siblings.
![image](https://user-images.githubusercontent.com/48253331/203148102-1fe3efe9-f5a4-485c-b840-49217509ef38.png)
![image](https://user-images.githubusercontent.com/48253331/203148154-a9a8c417-1708-42a2-ad1c-8595bfb0d64b.png)

In the next image you can see a table with index, santa, santa's constrain, receiver, recevier's constrains. The last 2 rows contains the pairs, one per column.
![image](https://user-images.githubusercontent.com/48253331/203148180-c56db4c8-768f-4e48-8b38-6b7fd86dcfe2.png)
 